### PR TITLE
allow numOfLines of 0 by checking type before assigning default of 1

### DIFF
--- a/striplines.js
+++ b/striplines.js
@@ -8,7 +8,11 @@ function StripLines(numOfLines) {
         return new StripLines(numOfLines);
     }
     Transform.call(this);
-    this._numOfLines = numOfLines || 1;
+    if (typeof numOfLines !== 'number') {
+        this._numOfLines = 1;
+    } else {
+        this._numOfLines = numOfLines;
+    }
     this._removed    = 0;
 }
 


### PR DESCRIPTION
Thanks for contributing this project!

This is a breaking change and would require a major version bump. Have `0` passed as `numOfLines` seems like a good thing to support in the case that someone wants to conditionally strip no lines. Let me know if you need anything else!